### PR TITLE
nav: link to FCOS tracker

### DIFF
--- a/templates/structure.html
+++ b/templates/structure.html
@@ -21,7 +21,7 @@
     <nav>
         <a href="/faq"></svg>FAQ</a>
         <a href="https://discussion.fedoraproject.org/c/coreos">Discussion</a>
-        <a href="https://github.com/coreos">GitHub</a>
+        <a href="https://github.com/coreos/fedora-coreos-tracker">GitHub</a>
     </nav>
   </header>
 


### PR DESCRIPTION
Instead of just making the "GitHub" link go to the coreos org, link to
the tracker repo.